### PR TITLE
linux/hci: request DLE during init

### DIFF
--- a/const.go
+++ b/const.go
@@ -7,6 +7,11 @@ const DefaultMTU = 23
 // The maximum length of an attribute value shall be 512 octets [Vol 3, Part F, 3.2.9]
 const MaxMTU = 512 + 3
 
+// Data Length Extension (DLE) to increase Data Channel Protocol Data Unit (PDU).
+// This feature is requested during hci init.
+const MaxOctsDLE = 251
+const MaxTimeDLE = 2120
+
 // UUIDs ...
 var (
 	GAPUUID         = UUID16(0x1800) // Generic Access

--- a/linux/hci/cmd/cmd_gen.go
+++ b/linux/hci/cmd/cmd_gen.go
@@ -1529,6 +1529,31 @@ func (c *LERemoteConnectionParameterRequestReplyRP) Unmarshal(b []byte) error {
 	return unmarshal(c, b)
 }
 
+type LEWriteSuggDefaultDataLength struct {
+	MaxTxOctets uint16
+	MaxTxTime   uint16
+}
+
+func (c *LEWriteSuggDefaultDataLength) String() string {
+	return "LE Write Suggested Default Data Length (0x08|0x0024)"
+}
+
+func (c *LEWriteSuggDefaultDataLength) OpCode() int { return 0x08<<10 | 0x0024 }
+
+func (c *LEWriteSuggDefaultDataLength) Len() int { return 4 }
+
+func (c *LEWriteSuggDefaultDataLength) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+type LEWriteSuggDefaultDataLengthRP struct {
+	Status uint8
+}
+
+func (c *LEWriteSuggDefaultDataLengthRP) Unmarshal(b []byte) error {
+	return unmarshal(c, b)
+}
+
 // LERemoteConnectionParameterRequestNegativeReply implements LE Remote Connection Parameter Request Negative Reply (0x08|0x0021) [Vol 2, Part E, 7.8.32]
 type LERemoteConnectionParameterRequestNegativeReply struct {
 	ConnectionHandle uint16

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -222,6 +222,10 @@ func (h *HCI) init() error {
 	WriteLEHostSupportRP := cmd.WriteLEHostSupportRP{}
 	h.Send(&cmd.WriteLEHostSupport{LESupportedHost: 1, SimultaneousLEHost: 0}, &WriteLEHostSupportRP)
 
+	LEWriteSuggDefaultDataLengthRP := cmd.LEWriteSuggDefaultDataLengthRP{}
+	h.Send(&cmd.LEWriteSuggDefaultDataLength{MaxTxOctets: ble.MaxOctsDLE, MaxTxTime: ble.MaxTimeDLE},
+		&LEWriteSuggDefaultDataLengthRP)
+
 	return h.err
 }
 


### PR DESCRIPTION
Using LL_FEATURE_REQ and LL_FEATURE_RSP,
Data Length Extension feature can be used if supported.
When supported, this feature is helpful to improve transfer rates.

When The MTU size is chosen accordingly, a higher throughput
can be obtained.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>